### PR TITLE
Support Zauth roles

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -24,7 +24,7 @@ config :zout, ZoutWeb.Endpoint,
 config :zout, Zout.Mailer, adapter: Swoosh.Adapters.Test
 
 # Print only warnings and errors during test
-config :logger, level: :warn
+config :logger, level: :warning
 
 # Initialize plugs at runtime for faster test compilation
 config :phoenix, :plug_init_mode, :runtime

--- a/lib/zout/accounts/accounts.ex
+++ b/lib/zout/accounts/accounts.ex
@@ -9,15 +9,18 @@ defmodule Zout.Accounts do
   def update_or_create!(%Ueberauth.Auth{
         uid: id,
         info: info,
-        extra: %Ueberauth.Auth.Extra{raw_info: %{admin: admin}}
+        extra: %Ueberauth.Auth.Extra{raw_info: %{admin: admin, roles: roles}}
       }) do
+
+    is_zout_admin = admin || Enum.member?(roles, "bestuur")
+
     case Repo.get(User, id) do
       nil -> %User{id: id}
       user -> user
     end
     |> User.changeset(%{
       nickname: info.nickname,
-      admin: admin
+      admin: is_zout_admin
     })
     |> Repo.insert_or_update!()
   end

--- a/lib/zout/accounts/accounts.ex
+++ b/lib/zout/accounts/accounts.ex
@@ -11,7 +11,6 @@ defmodule Zout.Accounts do
         info: info,
         extra: %Ueberauth.Auth.Extra{raw_info: %{admin: admin, roles: roles}}
       }) do
-
     is_zout_admin = admin || Enum.member?(roles, "bestuur")
 
     case Repo.get(User, id) do

--- a/lib/zout/accounts/accounts.ex
+++ b/lib/zout/accounts/accounts.ex
@@ -12,7 +12,9 @@ defmodule Zout.Accounts do
         extra: %Ueberauth.Auth.Extra{raw_info: %{admin: zauth_admin, roles: roles}}
       }) do
     user_roles = MapSet.new(roles)
-    has_admin_role = MapSet.intersection(admin_roles(), user_roles) |> Enum.empty?()
+
+    has_admin_role =
+      MapSet.intersection(admin_roles(), user_roles) |> Enum.empty?() |> Kernel.not()
 
     is_zout_admin = zauth_admin || has_admin_role
 

--- a/lib/zout/accounts/accounts.ex
+++ b/lib/zout/accounts/accounts.ex
@@ -9,9 +9,12 @@ defmodule Zout.Accounts do
   def update_or_create!(%Ueberauth.Auth{
         uid: id,
         info: info,
-        extra: %Ueberauth.Auth.Extra{raw_info: %{admin: admin, roles: roles}}
+        extra: %Ueberauth.Auth.Extra{raw_info: %{admin: zauth_admin, roles: roles}}
       }) do
-    is_zout_admin = admin || Enum.member?(roles, "bestuur")
+    user_roles = MapSet.new(roles)
+    has_admin_role = MapSet.intersection(admin_roles(), user_roles) |> Enum.empty?()
+
+    is_zout_admin = zauth_admin || has_admin_role
 
     case Repo.get(User, id) do
       nil -> %User{id: id}
@@ -28,4 +31,6 @@ defmodule Zout.Accounts do
   Get the user with the given ID.
   """
   def get_user(id), do: Repo.get(User, id)
+
+  defp admin_roles(), do: MapSet.new(["bestuur", "zout_admin"])
 end

--- a/lib/zout_web/auth/oauth_strategy.ex
+++ b/lib/zout_web/auth/oauth_strategy.ex
@@ -52,7 +52,10 @@ defmodule ZoutWeb.Auth.OAuthStrategy do
   end
 
   def authorize_url!() do
-    OAuth2.Client.authorize_url!(client())
+    OAuth2.Client.authorize_url!(
+      client(),
+      scope: "roles"
+    )
   end
 
   def get_token!(params \\ []) do

--- a/lib/zout_web/auth/ueberauth_strategy.ex
+++ b/lib/zout_web/auth/ueberauth_strategy.ex
@@ -78,7 +78,8 @@ defmodule ZoutWeb.Auth.UeberauthStrategy do
       raw_info: %{
         token: conn.private.zeus_token,
         user: conn.private.zeus_user,
-        admin: conn.private.zeus_user["admin"]
+        admin: conn.private.zeus_user["admin"],
+        roles: conn.private.zeus_user["roles"]
       }
     }
   end
@@ -99,7 +100,7 @@ defmodule ZoutWeb.Auth.UeberauthStrategy do
         set_errors!(conn, [error("OAuth2", reason)])
 
       {:error, _} ->
-        set_errors!(conn, [error("OAuth2", "uknown error")])
+        set_errors!(conn, [error("OAuth2", "unknown error")])
     end
   end
 end

--- a/test/zout/users_test.exs
+++ b/test/zout/users_test.exs
@@ -26,7 +26,7 @@ defmodule Zout.AccountsTest do
         info: %Ueberauth.Auth.Info{
           nickname: "new-user"
         },
-        extra: %Ueberauth.Auth.Extra{raw_info: %{admin: true}}
+        extra: %Ueberauth.Auth.Extra{raw_info: %{admin: true, roles: []}}
       }
 
       user_count_before = Repo.aggregate(User, :count, :id)
@@ -39,6 +39,23 @@ defmodule Zout.AccountsTest do
       assert_in_delta user_count_after, user_count_before, 1
     end
 
+    test "creates admin for zout admin role" do
+      new_user = %Ueberauth.Auth{
+        uid: 694,
+        info: %Ueberauth.Auth.Info{
+          nickname: "new-user-2"
+        },
+        extra: %Ueberauth.Auth.Extra{raw_info: %{admin: false, roles: ["zout_admin"]}}
+      }
+
+      user_count_before = Repo.aggregate(User, :count, :id)
+      inserted_user = Accounts.update_or_create!(new_user)
+      user_count_after = Repo.aggregate(User, :count, :id)
+
+      assert inserted_user.admin
+      assert_in_delta user_count_after, user_count_before, 1
+    end
+
     test "updates existing user" do
       existing_user = insert(:user, nickname: "before", admin: false)
 
@@ -47,7 +64,7 @@ defmodule Zout.AccountsTest do
         info: %Ueberauth.Auth.Info{
           nickname: "after"
         },
-        extra: %Ueberauth.Auth.Extra{raw_info: %{admin: true}}
+        extra: %Ueberauth.Auth.Extra{raw_info: %{admin: true, roles: []}}
       }
 
       user_count_before = Repo.aggregate(User, :count, :id)


### PR DESCRIPTION
This should work, but I don't have the `bestuur` role of course. We also still support the `admin` property of the user object, but not sure if that is still supported.